### PR TITLE
change the default color mode to 3bit

### DIFF
--- a/src/cl-ansi-text.lisp
+++ b/src/cl-ansi-text.lisp
@@ -35,7 +35,7 @@
   "Turns on/off the colorization.")
 
 (declaim (type (member :3bit :8bit :24bit) *color-mode*))
-(defvar *color-mode* :8bit
+(defvar *color-mode* :3bit
   "Controls the way `make-color-string` emits the color code.
 
 It should be one of the following keyword symbols: `:3bit`, `:8bit`, `:24bit`.


### PR DESCRIPTION
It seems `ansi-colors.el` does not support 8bit color and, as a result, colorize the input incorrectly.
While it is `ansi-colors.el`'s bug, it is an important target for this library, and it also seems to affect prove test library too, so it might be a better idea to keep it conservative.
