### PR TITLE
fix make-color-string's API violates the documentation.

### DIFF
--- a/cl-ansi-text.asd
+++ b/cl-ansi-text.asd
@@ -5,7 +5,7 @@
   :components ((:file "cl-ansi-text")
                (:file "define-colors"))
   :name "cl-ansi-text"
-  :version "1.1"
+  :version "1.2"
   :maintainer "Paul Nathan"
   :author "Paul Nathan"
   :licence "LLGPL"

--- a/src/cl-ansi-text.lisp
+++ b/src/cl-ansi-text.lisp
@@ -139,7 +139,7 @@ effect should be a member of +term-effects+"
 (defun make-color-string (color &key
 				  (effect :unset)
 				  (style :foreground)
-				  ((enabled *enabled*) *enabled*))
+				  ((:enabled *enabled*) *enabled*))
   "Takes an object of `color-specifier` and returns a string sufficient to change to the given color.
 
 Colorization is controlled by *enabled* unless manually specified otherwise by `:enabled` keyword."

--- a/test/cl-ansi-text-test.lisp
+++ b/test/cl-ansi-text-test.lisp
@@ -35,6 +35,10 @@
     (is (equal  '()
                 (let ((*enabled* nil))
                   (make-color-string-as-list :red))))
+    (is (equal '(#\Esc #\[ #\3 #\1 #\m)
+               (make-color-string-as-list :red :enabled t)))
+    (is (equal '()
+               (make-color-string-as-list :red :enabled nil)))
     (is (equal "hi"
                (let ((*enabled* nil))
                  (with-output-to-string (s)


### PR DESCRIPTION
API violates the documentation.

```lisp
(cl-ansi-text:make-color-string 0 :enabled t) => error, no such key supported.

(cl-ansi-text:make-color-string 0 'enabled t) => error, no such key supported.

(cl-ansi-text:make-color-string 0 'cl-ansi-text::enabled t) => works
```

This pr fixes it.