### PR TITLE
Fix color-specifer to use null rather than nil.

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ You can bind the `*enabled*` special variable to `nil` to control the colorizati
     (cons (real 0 256)
           (cons (real 0 256)
                 (cons (real 0 256)
-                      nil)))
+                      null)))
     cl-colors:rgb
     cl-colors:hsv
     term-colors

--- a/src/cl-ansi-text.lisp
+++ b/src/cl-ansi-text.lisp
@@ -105,7 +105,7 @@ the terminal setting -- For example, many terminals do not use `FF0000` for the 
        (cons (real 0 256)
              (cons (real 0 256)
                    (cons (real 0 256)
-                         nil)))
+                         null)))
        cl-colors2:rgb
        cl-colors2:hsv
        term-colors


### PR DESCRIPTION
This is a typical pitfall.

`NIL` does not match any type.

```lisp
(typep nil nil) => NIL
(typep nil 'null) => T

(typep '(0) '(cons fixnum nil)) => NIL
(typep '(0) '(cons fixnum null)) => T
```

